### PR TITLE
Fix socket port conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ data/
 python3 main_panel.py   # 패널 실행
 python3 chatbot.py      # 챗봇 실행
 ```
+패널은 기본적으로 포트 `7777`에서, 챗봇은 포트 `7778`에서 동작합니다.
+필요하다면 `communication.start_server()`와 `send_message()` 함수의
+`host`/`port` 인자를 수정해 다른 포트를 사용할 수 있습니다.
 
 두 프로그램을 동시에 실행하면 패널에서 감지한 패턴이나 사용자 명령이 챗봇으로
 전송되고, 챗봇에서 Yes/No 버튼이나 직접 입력으로 답할 수 있습니다.

--- a/chatbot.py
+++ b/chatbot.py
@@ -31,8 +31,9 @@ class ChatBot(QWidget):
         self.resize(400, 300)
         self.history: List[str] = []
         self._init_ui()
-        # Start socket server to receive messages from the panel
-        communication.start_server(self.receive_message)
+        # Start socket server to receive messages from the panel on a
+        # different port to avoid clashing with the panel's server
+        communication.start_server(self.receive_message, port=7778)
 
     def _init_ui(self) -> None:
         layout = QVBoxLayout(self)

--- a/communication.py
+++ b/communication.py
@@ -16,13 +16,32 @@ class Communicator:
         self.host = "127.0.0.1"
 
     # ------------------------------------------------------------------
-    def start_server(self, message_handler: Callable[[Dict[str, Any]], None]) -> None:
-        """Start a background server that invokes ``message_handler`` for each message."""
+    def start_server(
+        self,
+        message_handler: Callable[[Dict[str, Any]], None],
+        *,
+        host: str | None = None,
+        port: int | None = None,
+    ) -> None:
+        """Start a background server that invokes ``message_handler`` for each message.
+
+        Parameters
+        ----------
+        message_handler: Callable[[Dict[str, Any]], None]
+            Callback invoked with each decoded message.
+        host: str, optional
+            Host address to bind the server on. Defaults to ``self.host``.
+        port: int, optional
+            Port number for the server. Defaults to ``self.port``.
+        """
+
+        listen_host = host or self.host
+        listen_port = port or self.port
 
         def run() -> None:
             server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            server.bind((self.host, self.port))
+            server.bind((listen_host, listen_port))
             server.listen()
             while True:
                 conn, _ = server.accept()
@@ -67,8 +86,23 @@ class Communicator:
 _default = Communicator()
 
 
-def start_server(on_message: Callable[[str], None]) -> None:
-    """Start a simple server that forwards only the message text to ``on_message``."""
+def start_server(
+    on_message: Callable[[str], None],
+    *,
+    host: str | None = None,
+    port: int | None = None,
+) -> None:
+    """Start a simple server that forwards only the message text to ``on_message``.
+
+    Parameters
+    ----------
+    on_message: Callable[[str], None]
+        Callback invoked with the received message text.
+    host: str, optional
+        Host address to bind the server on. Defaults to ``_default.host``.
+    port: int, optional
+        Port number for the server. Defaults to ``_default.port``.
+    """
 
     def wrapper(msg: Dict[str, Any]) -> None:
         if msg.get("type") == "text":
@@ -76,9 +110,14 @@ def start_server(on_message: Callable[[str], None]) -> None:
         else:
             on_message(json.dumps(msg, ensure_ascii=False))
 
-    _default.start_server(wrapper)
+    _default.start_server(wrapper, host=host, port=port)
 
 
-def send_message(message: str) -> None:
-    """Send a plain text ``message`` to the default server."""
-    _default.send_message(_default.host, _default.port, {"type": "text", "data": message})
+def send_message(
+    message: str,
+    *,
+    host: str | None = None,
+    port: int | None = None,
+) -> None:
+    """Send a plain text ``message`` to the default server or the specified address."""
+    _default.send_message(host or _default.host, port or _default.port, {"type": "text", "data": message})

--- a/main_panel.py
+++ b/main_panel.py
@@ -402,7 +402,10 @@ class MainPanel(QMainWindow):
             and self.detected_patterns[device_name].get(time_key)
             and (device_name, time_key) not in self.sent_patterns
         ):
-            send_message(f"패턴 감지: {device_name} {time_key} {value}")
+            # Send the notification to the chatbot's server running on port 7778
+            send_message(
+                f"패턴 감지: {device_name} {time_key} {value}", port=7778
+            )
             self.sent_patterns.add((device_name, time_key))
             self.pending_event = event
             self.paused_for_chatbot = True


### PR DESCRIPTION
## Summary
- allow custom host/port in `communication.start_server` and `send_message`
- start ChatBot server on port `7778`
- send notifications from the panel to the chatbot using the new port
- mention default ports in the README

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf907a998832cb7bb0e88225002f0