### PR TITLE
Loop Play and Record automatically

### DIFF
--- a/main_panel.py
+++ b/main_panel.py
@@ -483,7 +483,10 @@ class MainPanel(QMainWindow):
             self.apply_event(event)
             self.service_index += 1
         if self.sim_end_time and self.sim_time >= self.sim_end_time:
-            self.toggle_service()
+            # Restart the service from the beginning once the
+            # simulation period is finished.
+            self.toggle_service()  # stop the current run
+            self.toggle_service()  # start a new run from the beginning
 
     def apply_event(self, event: dict) -> None:
         device_name = event["device"]


### PR DESCRIPTION
## Summary
- restart the service after the simulation period ends

## Testing
- `python test_csv_db.py`

------
https://chatgpt.com/codex/tasks/task_e_685d36cd8e60832cb59e768451c0eb99