### PR TITLE
Enable scrolling for main panel

### DIFF
--- a/main_panel.py
+++ b/main_panel.py
@@ -31,6 +31,7 @@ from PyQt5.QtWidgets import (
     QGroupBox,
     QSlider,
     QWidget,
+    QScrollArea,
 )
 
 from datetime import datetime, date, timedelta
@@ -68,7 +69,10 @@ class MainPanel(QMainWindow):
     # UI setup
     def _init_ui(self) -> None:
         central = QWidget()
-        self.setCentralWidget(central)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(central)
+        self.setCentralWidget(scroll)
         root_layout = QVBoxLayout(central)
 
         # Top tabs


### PR DESCRIPTION
## Summary
- add `QScrollArea` to support scrolling when the main window content is larger than the window

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_685d73f8d8b0832cb8ed08b52d96f96b