### PR TITLE
Fix union annotation crash

### DIFF
--- a/communication.py
+++ b/communication.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import socket
 import threading
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 
 class Communicator:
@@ -20,8 +20,8 @@ class Communicator:
         self,
         message_handler: Callable[[Dict[str, Any]], None],
         *,
-        host: str | None = None,
-        port: int | None = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
     ) -> None:
         """Start a background server that invokes ``message_handler`` for each message.
 
@@ -89,8 +89,8 @@ _default = Communicator()
 def start_server(
     on_message: Callable[[str], None],
     *,
-    host: str | None = None,
-    port: int | None = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
 ) -> None:
     """Start a simple server that forwards only the message text to ``on_message``.
 
@@ -116,8 +116,8 @@ def start_server(
 def send_message(
     message: str,
     *,
-    host: str | None = None,
-    port: int | None = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
 ) -> None:
     """Send a plain text ``message`` to the default server or the specified address."""
     _default.send_message(host or _default.host, port or _default.port, {"type": "text", "data": message})

--- a/csv_database.py
+++ b/csv_database.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import csv
 import os
 from datetime import datetime
-from typing import List, Tuple, Dict, Any
+from typing import List, Tuple, Dict, Any, Optional, Union
 from pathlib import Path
 
 
@@ -57,7 +57,7 @@ class SmartHomeCSV:
     # ------------------------------------------------------------------
     # 패턴 저장 관련 메서드
     
-    def save_pattern(self, timestamp: datetime | str, device: str, action: str) -> None:
+    def save_pattern(self, timestamp: Union[datetime, str], device: str, action: str) -> None:
         """
         사용 패턴 데이터를 CSV 파일에 저장
         
@@ -74,7 +74,7 @@ class SmartHomeCSV:
             writer = csv.writer(f)
             writer.writerow([timestamp, device, action])
 
-    def get_patterns(self, start_date: datetime | str, end_date: datetime | str) -> List[Tuple]:
+    def get_patterns(self, start_date: Union[datetime, str], end_date: Union[datetime, str]) -> List[Tuple]:
         """
         지정된 기간의 패턴 데이터를 반환
         
@@ -164,7 +164,7 @@ class SmartHomeCSV:
     # ------------------------------------------------------------------
     # 디바이스 상태 관리 관련 메서드
     
-    def update_device_status(self, device: str, status: str, type_: str | None = None) -> None:
+    def update_device_status(self, device: str, status: str, type_: Optional[str] = None) -> None:
         """
         디바이스 상태를 업데이트하거나 새로 생성
         
@@ -197,7 +197,7 @@ class SmartHomeCSV:
         # CSV 파일에 저장
         self._save_devices(devices)
 
-    def get_device_status(self, device: str) -> str | None:
+    def get_device_status(self, device: str) -> Optional[str]:
         """
         디바이스의 현재 상태를 반환
         

--- a/data_generator.py
+++ b/data_generator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import csv
 import random
 from datetime import datetime, date, time, timedelta
-from typing import Iterable, List, Dict, Any
+from typing import Iterable, List, Dict, Any, Union
 
 __all__ = [
     "generate_daily_pattern",
@@ -19,7 +19,7 @@ __all__ = [
 Event = Dict[str, Any]
 
 
-def _ensure_date(day: date | str) -> date:
+def _ensure_date(day: Union[date, str]) -> date:
     """Return ``day`` as :class:`~datetime.date`."""
 
     if isinstance(day, date):
@@ -27,7 +27,7 @@ def _ensure_date(day: date | str) -> date:
     return datetime.strptime(str(day), "%Y-%m-%d").date()
 
 
-def generate_daily_pattern(day: date | str) -> List[Event]:
+def generate_daily_pattern(day: Union[date, str]) -> List[Event]:
     """Return a list of events for a typical day.
 
     The pattern is as follows (24h time):

--- a/database_sqlite_backup.py
+++ b/database_sqlite_backup.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from datetime import datetime
-from typing import List, Tuple
+from typing import List, Tuple, Optional, Union
 
 
 class SmartHomeDB:
@@ -50,7 +50,7 @@ class SmartHomeDB:
 
     # ------------------------------------------------------------------
     # Pattern storage helpers
-    def save_pattern(self, timestamp: datetime | str, device: str, action: str) -> None:
+    def save_pattern(self, timestamp: Union[datetime, str], device: str, action: str) -> None:
         """Insert a usage pattern entry."""
 
         if isinstance(timestamp, datetime):
@@ -61,7 +61,7 @@ class SmartHomeDB:
         )
         self.conn.commit()
 
-    def get_patterns(self, start_date: datetime | str, end_date: datetime | str) -> List[Tuple]:
+    def get_patterns(self, start_date: Union[datetime, str], end_date: Union[datetime, str]) -> List[Tuple]:
         """Return pattern rows between ``start_date`` and ``end_date``."""
 
         if isinstance(start_date, datetime):
@@ -95,7 +95,7 @@ class SmartHomeDB:
 
     # ------------------------------------------------------------------
     # Device helpers
-    def update_device_status(self, device: str, status: str, type_: str | None = None) -> None:
+    def update_device_status(self, device: str, status: str, type_: Optional[str] = None) -> None:
         """Update status for ``device``; create the row if needed."""
 
         self.conn.execute(

--- a/extended_devices.py
+++ b/extended_devices.py
@@ -5,7 +5,7 @@
 """
 
 from dataclasses import dataclass
-from typing import Union, Dict, Any
+from typing import Union, Dict, Any, Optional
 from enum import Enum
 
 
@@ -32,8 +32,8 @@ class ExtendedPlanDevice:
     y: int                              # 평면도상 Y 좌표
     state: bool = False                 # 기본 ON/OFF 상태
     properties: Dict[str, Any] = None   # 추가 속성들
-    icon_on: str | None = None          # ON 상태 아이콘 경로
-    icon_off: str | None = None         # OFF 상태 아이콘 경로
+    icon_on: Optional[str] = None       # ON 상태 아이콘 경로
+    icon_off: Optional[str] = None      # OFF 상태 아이콘 경로
     
     def __post_init__(self):
         if self.properties is None:
@@ -106,7 +106,7 @@ EXTENDED_COLOR_ON = {
 EXTENDED_COLOR_OFF = "#808080"  # 모든 디바이스 꺼진 상태: 회색
 
 
-def get_device_by_id(device_id: int) -> Union[ExtendedPlanDevice, None]:
+def get_device_by_id(device_id: int) -> Optional[ExtendedPlanDevice]:
     """ID로 디바이스 찾기"""
     for device in extended_devices:
         if device.id == device_id:

--- a/floor_plan.py
+++ b/floor_plan.py
@@ -6,6 +6,7 @@
 """
 
 from dataclasses import dataclass
+from typing import Optional
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor, QPixmap, QPainter, QFont
 from PyQt5.QtGui import QPen
@@ -223,8 +224,8 @@ class PlanDevice:
     x: int
     y: int
     state: bool = False
-    icon_on: str | None = None
-    icon_off: str | None = None
+    icon_on: Optional[str] = None
+    icon_off: Optional[str] = None
 
 
 # 기존 devices 리스트 (하위 호환성용)

--- a/main_panel.py
+++ b/main_panel.py
@@ -36,7 +36,7 @@ from PyQt5.QtWidgets import (
 
 from datetime import datetime, date, timedelta
 
-from typing import Any
+from typing import Any, Optional
 
 from communication import start_server, send_message
 from csv_database import SmartHomeCSV
@@ -314,9 +314,9 @@ class MainPanel(QMainWindow):
         self.service_running = False
         self.step_mode = False
         self.paused_for_chatbot = False
-        self.pending_event: dict | None = None
-        self.sim_time: datetime | None = None
-        self.sim_end_time: datetime | None = None
+        self.pending_event: Optional[dict] = None
+        self.sim_time: Optional[datetime] = None
+        self.sim_end_time: Optional[datetime] = None
         self.service_index = 0
 
 


### PR DESCRIPTION
## Summary
- support Python 3.9 by replacing `|` unions with `Optional`/`Union`
- update affected dataclasses and helper functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_686b7019005c832c9c63bb37e490e8da